### PR TITLE
Fix: Zoom avatar not appearing

### DIFF
--- a/zoom.js
+++ b/zoom.js
@@ -39,7 +39,7 @@
 		var img = false;
 		var chatimg = "";
 		try{
-		   chatimg = ele.querySelector(".chat-item__user-avatar").querySelector("img").src;
+		   chatimg = ele.querySelector(".chat-item__chat-info-msg-avatar").src;
 		   img = true;
 			// lastImage = chatimg;
 		} catch(e){


### PR DESCRIPTION
The Zoom image avatar CSS has changed in recent Zoom Web updates.

This PR targets the image in its new place and fix the problem of Zoom avatar images not appearing in the chat overlay.