### PR TITLE
prevent zoom chat messages from stop working

### DIFF
--- a/zoom.js
+++ b/zoom.js
@@ -229,6 +229,13 @@
 		if (document.getElementById("poll__body")){
 			streamPollRAW(document.getElementById("poll__body"));
 		}
-	},1000);
 
+		if (document.getElementById('chat-list-content')) {
+		    document.getElementById('chat-list-content').scrollTop = 10000; // prevent chat box from stop scrolling, which makes messages stop appearing
+		}
+
+		if (document.querySelector('[aria-label="open the chat pane"]')) { // prevent chat box from being closed after screen-share by keeping it always open
+		    document.querySelector('[aria-label="open the chat pane"]').click()
+		}
+	},1000);
 })();


### PR DESCRIPTION
This PR fixes two problems that was interrupting Social Stream on Zoom:

1- When a lot of messages are sent at once, the scroll stops and—because of the Zoom infinite scroll optimization—the messages doesn't appear on the HTML.

The fix for that was adding to the loop scroll down moviment, so that the chat always stay on the bottom

![CleanShot 2022-07-28 at 18 12 14@2x](https://user-images.githubusercontent.com/1354492/181657862-985ac4a2-f7c2-4190-90f1-b10193231d89.jpg)

2- When someone shares the screen, the chat box closes and doesn't open afterwards, so messages stop appearing

The fix for that was adding to the loop tapping the "open chat" menu, that is only visible when it is closed

