### PR TITLE
Updated SPX integration + info on how to use

### DIFF
--- a/dock.html
+++ b/dock.html
@@ -1468,7 +1468,7 @@
 		thirdPartyAPI = function (data){
 			ajax(data, postServer, "PUT");
 		};
-		} else if (urlParams.has("spxserver") && urlParams.has("spxfunction") && urlParams.has("spxlayer")) {
+	} else if (urlParams.has("spxserver") && urlParams.has("spxfunction") && urlParams.has("spxlayer")) {
 		let spxserver = urlParams.get("spxserver") || postServer;
 		let spxfunction = urlParams.get("spxfunction") || "";
 		let spxlayer = urlParams.get("spxlayer") || "";

--- a/dock.html
+++ b/dock.html
@@ -1468,7 +1468,7 @@
 		thirdPartyAPI = function (data){
 			ajax(data, postServer, "PUT");
 		};
-	} else if (urlParams.has("spxserver") && urlParams.has("spxfunction") && urlParams.has("spxlayer")) {
+		} else if (urlParams.has("spxserver") && urlParams.has("spxfunction") && urlParams.has("spxlayer")) {
 		let spxserver = urlParams.get("spxserver") || postServer;
 		let spxfunction = urlParams.get("spxfunction") || "";
 		let spxlayer = urlParams.get("spxlayer") || "";
@@ -1494,9 +1494,13 @@
 				msg.platform.name = data.type;
 				msg.platform.logoUrl = "https://socialstream.ninja/"+data.type+".png";
 			}
-			
-			msg = JSON.stringify(msg);
-			let params = btoa(unescape(encodeURIComponent(msg)));
+				
+			params = encodeURIComponent(JSON.stringify(msg));
+
+			if (params.length > 3000) {
+				console.log("dropping message due to request length");
+				return; // HTTP request too long due to twitch emoji spam, skipping this message. 
+			}
 			postServer = spxserver + "/api/v1/invokeTemplateFunction?webplayout=" + spxlayer + "&function=" + spxfunction + "&params=" + params;
 
 			const spxRequest = new XMLHttpRequest();


### PR DESCRIPTION
- Fixed bug with custom Twitch emojis which resulted in huge queries
- Cleaned a bit

Usage: 
usage: append following parameters to dock.html: spxserver=http://xxxxxxxx/:80&spxfunction=myCustomFunction&spxlayer=11

SPX templates can use the data like this: 

// decode incoming json data
let decodedText = decodeURIComponent(params);
let data = JSON.parse(decodedText);
				
// update SPX with received data
document.getElementById('f0').innerHTML = data.displayName;
document.getElementById('f1').innerHTML = data.message;
document.getElementById('f2').src = data.profileImageUrl;

The following data is also available:

data.platform.name 
data.platform.logoUrl 

More can be added by request
