### PR TITLE
Fix the issue where the queue couldn't display upscaled images after using localized display name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1115,15 +1115,15 @@ yt-live-chat-membership-item-renderer[is-deleted] {
 					data.chatimg = "";
 				}
 				
-				<!-- try { -->
-					<!-- if (data.type && (data.type == "facebook") && data.userID ){ -->
-						<!-- var tmpImage2 = new Image(); -->
-						<!-- tmpImage2.src = "https://graph.facebook.com/"+data.userID+"/picture?type=large"; -->
-						<!-- tmpImage2.onload = function(){ -->
-							<!-- document.getElementById("img_"+data.chatname).src = tmpImage2.src; -->
-						<!-- }; -->
-					<!-- } -->
-				<!-- } catch(e){} -->
+				// <!-- try { -->
+				// 	<!-- if (data.type && (data.type == "facebook") && data.userID ){ -->
+				// 		<!-- var tmpImage2 = new Image(); -->
+				// 		<!-- tmpImage2.src = "https://graph.facebook.com/"+data.userID+"/picture?type=large"; -->
+				// 		<!-- tmpImage2.onload = function(){ -->
+				// 			<!-- document.getElementById("img_"+data.chatname).src = tmpImage2.src; -->
+				// 		<!-- }; -->
+				// 	<!-- } -->
+				// <!-- } catch(e){} -->
 				
 				var showType = "";
 				if (!data.type){
@@ -1283,9 +1283,9 @@ yt-live-chat-membership-item-renderer[is-deleted] {
 					document.getElementById("message").style = data.backgroundColor +' '+ data.textColor+'; font-size: '+fontsize+'%;';
 				}
 				
-				if ((data.type == "twitch") && avatar && data.chatname){
+				if ((data.type == "twitch") && avatar && data.username){
 					var twitchImage = new Image();
-					data.chatimg = "https://api.socialstream.ninja/twitch/large?username="+encodeURIComponent(data.chatname);
+					data.chatimg = "https://api.socialstream.ninja/twitch/large?username="+encodeURIComponent(data.username);
 					twitchImage.onload = function (){
 						try {
 							document.getElementById('img_'+data.id).src = data.chatimg;

--- a/twitch.js
+++ b/twitch.js
@@ -86,26 +86,24 @@
 	var lastUser  = "";
 	
 	function processMessage(ele){	// twitch
-	
+
 	  var chatsticker = false;
 	  var chatmessage = "";
 	  var nameColor = "";
-	  
-	  
+
 	  try {
-		var nameEle = ele.querySelector(".chat-author__display-name") || ele.querySelector(".seventv-chat-user-username");
-		var chatname = nameEle.innerText;
-		var displayName = chatname;
-		var displayNameEle = ele.querySelector(".chat-author__intl-login");
-		if ( displayNameEle ) {
-			displayName = displayNameEle.innerText.slice(2, -1);
+		var displayNameEle = ele.querySelector(".chat-author__display-name") || ele.querySelector(".seventv-chat-user-username");
+		var displayName = displayNameEle.innerText;
+		var username = displayName;
+		var usernameEle = ele.querySelector(".chat-author__intl-login");
+		if (usernameEle) {
+			username = usernameEle.innerText.slice(2, -1);
 		}
 
 		try {
 			nameColor = nameEle.style.color || ele.querySelector(".seventv-chat-user").style.color;
 		} catch(e){}
-	  } catch(e){
-	  }
+	  } catch(e){}
 	  
 	  var chatbadges = [];
 	  try {
@@ -163,13 +161,13 @@
 		 chatmessage = chatmessage.trim();
 	 }
 	 
-	 if ((lastMessage === chatmessage) && (lastUser === chatname)){
+	 if ((lastMessage === chatmessage) && (lastUser === username)){
 		  lastMessage = "";
-		  chatname = "";
+		  username = "";
 		  return;
 	  } else {
 		lastMessage = chatmessage;
-		lastUser = chatname;
+		lastUser = username;
 	  }
 	  
 	  if (chatmessage && chatmessage.includes(" (Deleted by ")){
@@ -211,24 +209,24 @@
 		hasDonation = donations;
 	  }
 	  
-	  if (!chatmessage && !hasDonation && !chatname){
+	  if (!chatmessage && !hasDonation && !username){
 		return;
 	  }
 
 	  var data = {};
-	  data.chatname = chatname;
+	  data.chatname = displayName;
+	  data.username = username;
 	  data.chatbadges = chatbadges;
 	  data.nameColor = nameColor;
 	  data.chatmessage = chatmessage;
 	  try {
-		data.chatimg = "https://api.socialstream.ninja/twitch/?username="+encodeURIComponent(displayName); // this is CORS restricted to socialstream, but this is to ensure reliability for all
+		data.chatimg = "https://api.socialstream.ninja/twitch/?username=" + encodeURIComponent(username); // this is CORS restricted to socialstream, but this is to ensure reliability for all
 	  } catch(e){
-		  data.chatimg = "";
+		data.chatimg = "";
 	  }
 	  data.hasDonation = hasDonation;
 	  data.hasMembership = "";
 	  data.type = "twitch";
-	  data.displayName = displayName;
 	  
 	//  console.log(data);
 	  


### PR DESCRIPTION
Hi, I fixed the issue with `index.html` not being able to retrieve the upscale image due to the use of localized display name in the queue.

In addition, I edited the variable names in `twitch.js` related to user names.
The text obtained from `chat-author__display-name` is defined as `displayName`.
The text obtained from `chat-author__intl-login` is defined as `username`.
![image](https://user-images.githubusercontent.com/27887647/230716190-b75a7d9c-1c7a-40d7-a121-adfba11d7267.png)

When localized display name is not used, `username = displayName`.
Otherwise, `username` will be changed to the user's original username.
I hope this will help with understanding the logic between Twitch's use of username and display name.