### PR TITLE
Fix: Zoom not working when PWA is deactivated

### DIFF
--- a/zoom.js
+++ b/zoom.js
@@ -331,7 +331,7 @@
 		var config = { childList: true, subtree: true };
 		var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 		var observer = new MutationObserver(onMutationsObserved);
-		observer.observe(target, config);
+		observer.observe(document.querySelector(target), config);
 
 	}
 	console.log("social stream injected");


### PR DESCRIPTION
When the Zoom url has `fromPwa=0`, the app is not loaded inside the iframe, and thus triggering the first part of the conditional. The thing is that `target` is a string, so it needs to be converted into an element before continuing.