### PR TITLE
Fix: typo on sampleapi.html

### DIFF
--- a/sampleapi.html
+++ b/sampleapi.html
@@ -458,7 +458,7 @@ function loadSelfCommands(){
 	target_self.appendChild(br);
 	
 	var title = document.createElement("h3");
-	title.innerText = "Fake as a Twitch message via POST requset";
+	title.innerText = "Fake as a Twitch message via POST request";
 	target_self.appendChild(title);
 	
 	var button = document.createElement("button");
@@ -520,7 +520,7 @@ function loadSelfCommands(){
 	/////
 	
 	var title = document.createElement("h3");
-	title.innerText = "Fake as a Twitch message via GET requset";
+	title.innerText = "Fake as a Twitch message via GET request";
 	target_self.appendChild(title);
 	
 	var button = document.createElement("button");


### PR DESCRIPTION
Fixed a typo on `request` word.


Taking advantage of this PR, one question @steveseguin , how difficult is to add a new field on this form to insert an image link to use as avatar instead of using the Twitch -> account -> avatar.

![Screenshot 2024-05-07 at 7 11 48 PM](https://github.com/steveseguin/social_stream/assets/4898256/4c3c42ca-4980-4b26-a99b-cfd3510cc95a)

Thanks for this great tool! 