### PR TITLE
WIP: BEAM Stream emotes

### DIFF
--- a/beamstream.js
+++ b/beamstream.js
@@ -61,9 +61,10 @@
 			} else if (node.nodeType === 1){
 				if (!settings.textonlymode){
 					if ((node.nodeName == "IMG") && node.src){
-						node.src = node.src+"";
+						resp += `<img src='${node.src}' />`;
+					} else {
+						resp += node.outerHTML;
 					}
-					resp += node.outerHTML;
 				}
 			}
 		});

--- a/sources/beamstream.js
+++ b/sources/beamstream.js
@@ -61,9 +61,10 @@
 			} else if (node.nodeType === 1){
 				if (!settings.textonlymode){
 					if ((node.nodeName == "IMG") && node.src){
-						node.src = node.src+"";
+						resp += `<img src='${node.src}' />`;
+					} else {
+						resp += node.outerHTML;
 					}
-					resp += node.outerHTML;
 				}
 			}
 		});

--- a/sources/beamstream.js
+++ b/sources/beamstream.js
@@ -53,14 +53,23 @@
 			}
 		}
 		
-		element.childNodes.forEach(node=>{
-			if (node.childNodes.length){
-				resp += getAllContentNodes(node)
-			} else if ((node.nodeType === 3) && node.textContent && (node.textContent.trim().length > 0)){
+		// Sticker-only messages
+		if (element.nodeName == "IMG" && element.src) {
+			if (!settings.textonlymode) {
+				return `<img src='${element.src}' />`;
+			} else {
+				return element.outerHTML;
+			}
+		}
+
+		element.childNodes.forEach(node => {
+			if (node.childNodes.length) {
+				resp += getAllContentNodes(node);
+			} else if (node.nodeType === 3 && node.textContent && node.textContent.trim().length > 0) {
 				resp += escapeHtml(node.textContent);
-			} else if (node.nodeType === 1){
-				if (!settings.textonlymode){
-					if ((node.nodeName == "IMG") && node.src){
+			} else if (node.nodeType === 1) {
+				if (!settings.textonlymode) {
+					if (node.nodeName == "IMG" && node.src) {
 						resp += `<img src='${node.src}' />`;
 					} else {
 						resp += node.outerHTML;
@@ -68,6 +77,7 @@
 				}
 			}
 		});
+
 		return resp;
 	}
 	


### PR DESCRIPTION
- Strips `style` and any other future attributes set on `<img />` corresponding to external emotes (e.g., Twitch/Kick/YouTube/Facebook, etc.)
- Adds support for internal emotes