### PR TITLE
fix(overlay): Hide conflicting options based on style/preset

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.25.15",
+  "version": "3.26.0",
   "homepage_url": "http://socialstream.ninja/",
   "icons": {
     "128": "icons/icon-128.png"

--- a/popup.js
+++ b/popup.js
@@ -1622,7 +1622,15 @@ function processObjectSetting(key, settingObj, sync, paramNums, response) { // A
                 handleAIProviderVisibility(ele.value);
             } else if (key == "ttsProvider") {
                 handleTTSProviderVisibility(ele.value);
-            } 
+            } else if (key == "featuredOverlayStyle" ) {
+				document.querySelectorAll('.wrapper:has(.options_group.single_message)').forEach(wrapper => {
+					wrapper.style.display = 'none';
+				});
+			 } else if (key == "overlayPreset") {
+				document.querySelectorAll('.wrapper:has(.options_group.streaming_chat)').forEach(wrapper => {
+					wrapper.style.display = 'none';
+				});
+			 }
         }
     }
 


### PR DESCRIPTION
Addresses UI issue where settings for incompatible overlay features remained visible when a specific overlay style or preset was selected.

Adds logic in popup.js to hide specific options groups (`.wrapper:has(...)`) when the `featuredOverlayStyle` or `overlayPreset` settings are changed, improving clarity in the settings interface. Also includes version bump in manifest.json.

[auto-enhanced]