### PR TITLE
```

### DIFF
--- a/featured.html
+++ b/featured.html
@@ -2372,6 +2372,9 @@
 								if (volume) {
 									audio.volume = volume;
 								}
+								if (!audioContext) {
+									initAudioContext();
+								}
 								if (audioContext.state === 'suspended') {
 									await audioContext.resume();
 								}
@@ -2441,6 +2444,9 @@
 						if (volume) {
 							audio.volume = volume;
 						}
+						if (!audioContext) {
+							initAudioContext();
+						}
 						if (audioContext.state === 'suspended') {
 							await audioContext.resume();
 						}
@@ -2487,6 +2493,9 @@
 						audio.src = blobUrl;
 						if (volume) {
 							audio.volume = volume;
+						}
+						if (!audioContext) {
+							initAudioContext();
 						}
 						if (audioContext.state === 'suspended') {
 							await audioContext.resume();


### PR DESCRIPTION
fix(featured): Ensure audio context is initialized before resume

Adds a check to verify that the audio context is initialized before attempting to resume it in the audio playback handlers within featured.html.

This prevents potential errors if audioContext is null or undefined when playback is triggered, ensuring reliable audio output for features like chat notifications.
```

[auto-enhanced]