### PR TITLE
fix(css): Ensure portfolio modal images display correctly

### DIFF
--- a/docs/css/services.css
+++ b/docs/css/services.css
@@ -263,9 +263,7 @@
 	overflow: hidden;
 }
 
-.portfolio-modal-img{
-	display:block!important;
-}
+
 .portfolio-thumb {
     width: 8rem;
     height: 6rem;
@@ -681,7 +679,7 @@
     max-height: 90%;
     border-radius: var(--radius-md);
     object-fit: contain;
-    display: block;
+   display:block!important;
 }
 
 .portfolio-modal-close {


### PR DESCRIPTION
### Purpose

This Pull Request addresses an issue where images within the portfolio modal were not consistently displaying or rendering correctly across the "Raspberry Ninja" project. The primary goal is to ensure robust and consistent image visibility within these modals.

### Key Changes

*   **Removed Specific CSS Rule:** The `.portfolio-modal-img` CSS rule has been removed from the stylesheet. This rule was identified as potentially redundant or conflicting.
*   **Applied `!important` for Display Property:** An `!important` declaration has been added to the `display: block` property for `portfolio-modal img` within `docs/css/services.css`. This ensures that images within the portfolio modal consistently render as block-level elements, effectively overriding any conflicting styles from other parts of the CSS cascade.

### Context & Rationale

The previous CSS styling sometimes led to images within the portfolio modals not appearing, being misaligned, or rendering inconsistently. By removing a potentially problematic specific rule and explicitly enforcing `display: block` with `!important`, we resolve these display issues. This change guarantees that portfolio images are always visible and correctly rendered, enhancing the visual integrity and user experience when interacting with project details.

### How to Test

1.  Navigate to any section of the application that utilizes the portfolio modal.
2.  Open various portfolio modals (e.g., by clicking on project thumbnails or service entries).
3.  Verify that all images within these modals are displayed correctly, are fully visible, and render without any layout issues.
4.  (Optional) Test the modals on different browser types or screen resolutions to confirm consistency.