### PR TITLE
fixed link towards the luckyloottube.html chat theme

### DIFF
--- a/docs/templates.html
+++ b/docs/templates.html
@@ -271,7 +271,7 @@
                             <div class="template-footer">
                                 <div class="template-author">By LuckyLootTube</div>
                                 <div class="template-actions">
-                                    <a href="https://socialstream.ninja/themes/LuckyLootTube/luckyloottube.html?session=YOURSESSIONIDHERE=3.40.2" class="btn btn-primary">Use</a>
+                                    <a href="https://socialstream.ninja/themes/LuckyLootTube/luckyloottube.html?session=YOURSESSIONIDHERE&v=3.40.2" class="btn btn-primary">Use</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
it was a copy-pasta from the neighbor above which did not work for luckyloottube.html - fixed now :D

Replaced
"https://socialstream.ninja/themes/t3nk3y/?session=YOURSESSIONIDHERE"

With
"https://socialstream.ninja/themes/LuckyLootTube/luckyloottube.html?session=YOURSESSIONIDHERE=3.40.2"