### PR TITLE
fix(youtube): improve auto-live chat switching reliability

### DIFF
--- a/sources/youtube.js
+++ b/sources/youtube.js
@@ -1504,12 +1504,12 @@
 			document.querySelector("#trigger").click()
 			document.querySelector('[slot="dropdown-content"] [tabindex="0"]').click()
 			var waitTilClear = setInterval(function(){
-				if (document.querySelectorAll('#menu > a').length==2){
+				if (document.querySelectorAll('#menu > a').length>=2){
 					clearInterval(waitTilClear);
 					document.querySelectorAll('#menu > a')[1].click()
 					document.querySelector("yt-live-chat-header-renderer").style.maxHeight = "10px";
 				}
-			},100)
+			},500)
 	  } else if (document.querySelector("#trigger") && !settings.autoLiveYoutube && marked){
 		  document.querySelector("yt-live-chat-header-renderer").style.maxHeight = "unset";
 		  marked = false;


### PR DESCRIPTION
- Update logic to handle cases where the chat menu contains more than two items by changing the length check to `>= 2`.
- Increase the polling interval from 100ms to 500ms to ensure UI elements are fully rendered before interaction.
- Refine the automated process of switching from "Top Chat" to "Live Chat" when `autoLiveYoutube` is enabled in settings.

[auto-enhanced]