### PR TITLE
feat(audio): add support for overlapping notification beeps

### DIFF
--- a/dock.html
+++ b/dock.html
@@ -3661,20 +3661,23 @@
 			}
 
 			async function playtone(tonename = "testtone") {
-				if (timeoutTone) {
-					return;
-				}
-				timeoutTone = true;
+				// Skip throttle if overlap mode enabled
+				if (!overlapBeep) {
+					if (timeoutTone) {
+						return;
+					}
+					timeoutTone = true;
 
-				setTimeout(function () {
-					timeoutTone = false;
-				}, 500);
+					setTimeout(function () {
+						timeoutTone = false;
+					}, 500);
+				}
 
 				// Initialize audio context on first use
 				if (!audioContext) {
 					initAudioContext();
 				}
-				
+
 				if (audioContext && audioContext.state == "suspended") {
 					try {
 						await audioContext.resume();
@@ -3691,17 +3694,50 @@
 				if (!audioContext || audioContext.state == "suspended") {
 					return;
 				}
-				var toneEle = document.getElementById(tonename);
-				if (toneEle) {
-					toneEle
-						.play()
-						.then(() => {
-							// beep
-						})
-						.catch(e => {
-							console.error(e);
-						});
+
+				if (overlapBeep) {
+					playOverlappingTone(tonename);
+				} else {
+					var toneEle = document.getElementById(tonename);
+					if (toneEle) {
+						toneEle
+							.play()
+							.then(() => {
+								// beep
+							})
+							.catch(e => {
+								console.error(e);
+							});
+					}
 				}
+			}
+
+			function playOverlappingTone(tonename) {
+				var sourceEle = document.getElementById(tonename);
+				if (!sourceEle) return;
+
+				var sources = sourceEle.getElementsByTagName("source");
+				var audioSrc = sources.length > 0 ? sources[0].src : sourceEle.src;
+				if (!audioSrc) return;
+
+				var tempAudio = new Audio(audioSrc);
+				tempAudio.volume = sourceEle.volume;
+
+				// Cleanup after playback
+				tempAudio.addEventListener('ended', function() {
+					tempAudio.src = '';
+					tempAudio = null;
+				});
+				tempAudio.addEventListener('error', function() {
+					tempAudio.src = '';
+					tempAudio = null;
+				});
+
+				tempAudio.play().catch(e => {
+					console.error('Overlapping tone error:', e);
+					tempAudio.src = '';
+					tempAudio = null;
+				});
 			}
 
 			if (urlParams.has("css")) {
@@ -4000,7 +4036,12 @@
 			if (urlParams.has("nobeepmod")) {
 				nobeepmod = true;
 			}
-			
+
+			var overlapBeep = false;
+			if (urlParams.has("overlapbeep")) {
+				overlapBeep = true;
+			}
+
 			var stylizeEmoji = false;
 			if (urlParams.has("emoji") || urlParams.has("emojis")) {
 				stylizeEmoji = urlParams.get("emoji") || urlParams.get("emojis") || "140";

--- a/popup.html
+++ b/popup.html
@@ -2066,6 +2066,13 @@ input:checked + .slider:before {
                                     <label for="custombeep"><span data-translate="custombeep">&gt; URL for custom beep audio file</span></label>
                                     <button type="button" id="uploadBeepBtn" style="position: absolute; right: 5px; top: 50%; transform: translateY(-50%); padding: 5px 10px; background: #667eea; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 12px;">Upload</button>
                                 </div>
+								<div title="Allow beep sounds to overlap when messages arrive quickly (experimental)" data-keywords="beep sound overlap concurrent multiple simultaneous experimental">
+                                    <label class="switch">
+                                        <input type="checkbox" data-param1="overlapbeep" />
+                                        <span class="slider round"></span>
+                                    </label>
+                                    <span>Allow overlapping beeps (experimental)</span>
+                                </div>
                                 <div data-keywords="refresh history backlog cache resume reconnect restore">
                                     <label class="switch">
                                         <input type="checkbox" data-param1="reload" />

--- a/shared/config/urlParameters.js
+++ b/shared/config/urlParameters.js
@@ -1658,6 +1658,15 @@ export const URL_PARAMETER_GROUPS = Object.freeze([
             "description": "Custom sound file URL for notifications"
           },
           {
+            "key": "overlapbeep",
+            "displayName": "overlapbeep",
+            "aliases": [
+              "overlapbeep"
+            ],
+            "values": "boolean",
+            "description": "Enables overlapping beep sounds for rapid messages (experimental)"
+          },
+          {
             "key": "beepwords",
             "displayName": "beepwords",
             "aliases": [


### PR DESCRIPTION
# PR Description

## Summary
This PR introduces an experimental feature to allow overlapping audio notification beeps. By bypassing the standard 500ms throttle, the application can now play multiple notification sounds concurrently when messages arrive in rapid succession, providing better auditory feedback for high-activity streams.

## Purpose
In the current implementation, audio notifications are throttled to prevent sound distortion or "noise fatigue" when many messages arrive at once. However, some users prefer to hear every individual notification. This change adds an optional setting to enable "Overlapping Beeps," giving users control over their auditory experience.

## Key Changes

### 🖥️ User Interface
- **Settings Popup:** Added an "Allow overlapping beeps" checkbox to `popup.html`. This allows users to toggle the feature easily from the extension/app interface.

### ⚙️ Logic & Core
- **Concurrent Playback:** Implemented `playOverlappingTone()` in `dock.html`. Unlike the standard `playtone()`, this function creates independent audio instances for each notification.
- **Throttling Bypass:** Updated the primary `playtone()` logic to check for the `overlapbeep` state. If enabled, it routes the audio request to the new overlapping handler instead of the throttled one.
- **Memory Management:** Added auto-cleanup logic to the dynamic `Audio` objects. Each temporary element is automatically removed/garbage collected after the `ended` or `error` event triggers to prevent memory leaks during long streaming sessions.

### 📝 Configuration
- **URL Parameters:** Registered the `overlapbeep` parameter in `shared/config/urlParameters.js`, allowing the feature to be enabled via URL query strings for Lite web app deployments or specific dock configurations.

## Technical Implementation Details
- The implementation uses the standard Web Audio API via `new Audio()`.
- To ensure performance stability, the `onended` event listener is utilized to nullify references to the audio object immediately after playback completes.

## How to Test
1. Open the Social Stream Ninja settings popup.
2. Enable the **"Allow overlapping beeps"** setting.
3. Trigger multiple chat messages in rapid succession (less than 500ms apart).
4. **Expected Result:** You should hear multiple overlapping pings instead of a single throttled ping.
5. Disable the setting and verify the behavior reverts to the standard 500ms throttled playback.

## Considerations
- **Resource Usage:** While memory cleanup is implemented, extremely high-volume chat (hundreds of messages per second) with this feature enabled may increase CPU usage due to concurrent audio decoding. This is marked as an "experimental" setting for this reason.