### PR TITLE
fix(firefox): remove deprecated --use-submission-api flag

### DIFF
--- a/.github/workflows/firefox-addon-store.yml
+++ b/.github/workflows/firefox-addon-store.yml
@@ -80,8 +80,7 @@ jobs:
             --api-secret "$AMO_JWT_SECRET" \
             --channel "$WEB_EXT_CHANNEL" \
             --source-dir "$FIREFOX_BUILD_DIR" \
-            --artifacts-dir "$ARTIFACTS_DIR" \
-            --use-submission-api; do
+            --artifacts-dir "$ARTIFACTS_DIR"; do
             if (( attempt >= max_attempts )); then
               echo "web-ext sign failed after ${attempt} attempts" >&2
               break


### PR DESCRIPTION
## Summary
Remove `--use-submission-api` flag from web-ext sign command.

In web-ext v8, the submission API is used by default and the flag was removed.

Reference: [web-ext command reference](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)