### PR TITLE
fix(firefox): add license metadata for AMO submission

### DIFF
--- a/.github/workflows/firefox-addon-store.yml
+++ b/.github/workflows/firefox-addon-store.yml
@@ -80,7 +80,8 @@ jobs:
             --api-secret "$AMO_JWT_SECRET" \
             --channel "$WEB_EXT_CHANNEL" \
             --source-dir "$FIREFOX_BUILD_DIR" \
-            --artifacts-dir "$ARTIFACTS_DIR"; do
+            --artifacts-dir "$ARTIFACTS_DIR" \
+            --amo-metadata "scripts/amo-metadata.json"; do
             if (( attempt >= max_attempts )); then
               echo "web-ext sign failed after ${attempt} attempts" >&2
               break

--- a/scripts/amo-metadata.json
+++ b/scripts/amo-metadata.json
@@ -1,0 +1,5 @@
+{
+  "version": {
+    "license": "GPL-3.0"
+  }
+}


### PR DESCRIPTION
AMO requires a license field for listed versions during the submission and signing process. This update ensures compliance with Mozilla Add-on Store requirements.

- Create `scripts/amo-metadata.json` specifying the GPL-3.0 license.
- Update `web-ext sign` in `.github/workflows/firefox-addon-store.yml` to utilize the new metadata file via the `--amo-metadata` flag.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

[auto-enhanced]