### PR TITLE
fix(firefox): use correct SPDX license identifier GPL-3.0-only

### DIFF
--- a/scripts/amo-metadata.json
+++ b/scripts/amo-metadata.json
@@ -1,5 +1,5 @@
 {
   "version": {
-    "license": "GPL-3.0"
+    "license": "GPL-3.0-only"
   }
 }


### PR DESCRIPTION
## Summary
- Use correct SPDX license slug `GPL-3.0-only` instead of `GPL-3.0`
- AMO requires exact SPDX identifiers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)