### PR TITLE
fix(firefox): add required category for AMO listing

### DIFF
--- a/scripts/amo-metadata.json
+++ b/scripts/amo-metadata.json
@@ -1,4 +1,7 @@
 {
+  "categories": {
+    "firefox": ["social-communication"]
+  },
   "version": {
     "license": "GPL-3.0-only"
   }


### PR DESCRIPTION
## Summary
- Add `social-communication` category required for AMO listed extensions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)