### PR TITLE
fix: Firefox workflow - handle listed channel without immediate XPI

### DIFF
--- a/.github/workflows/firefox-addon-store.yml
+++ b/.github/workflows/firefox-addon-store.yml
@@ -53,6 +53,7 @@ jobs:
         run: npm install --global web-ext@8
 
       - name: Submit to Firefox Add-ons Store
+        id: submit
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
@@ -73,19 +74,23 @@ jobs:
           attempt=1
           max_attempts=4
           backoff=30
-          success=false
 
-          until web-ext sign \
-            --api-key "$AMO_JWT_ISSUER" \
-            --api-secret "$AMO_JWT_SECRET" \
-            --channel "$WEB_EXT_CHANNEL" \
-            --source-dir "$FIREFOX_BUILD_DIR" \
-            --artifacts-dir "$ARTIFACTS_DIR" \
-            --amo-metadata "scripts/amo-metadata.json" \
-            --approval-timeout 0; do
+          while true; do
+            if web-ext sign \
+              --api-key "$AMO_JWT_ISSUER" \
+              --api-secret "$AMO_JWT_SECRET" \
+              --channel "$WEB_EXT_CHANNEL" \
+              --source-dir "$FIREFOX_BUILD_DIR" \
+              --artifacts-dir "$ARTIFACTS_DIR" \
+              --amo-metadata "scripts/amo-metadata.json" \
+              --approval-timeout 0; then
+              echo "Submission to AMO succeeded!"
+              break
+            fi
+
             if (( attempt >= max_attempts )); then
               echo "web-ext sign failed after ${attempt} attempts" >&2
-              break
+              exit 1
             fi
             echo "web-ext sign failed (attempt ${attempt}/${max_attempts}). Retrying in ${backoff}s..." >&2
             sleep "$backoff"
@@ -93,24 +98,25 @@ jobs:
             backoff=$((backoff * 2))
           done
 
+          # Check if we got a signed XPI (unlisted channel gives immediate XPI, listed does not)
           if ls "${ARTIFACTS_DIR}"/*.xpi >/dev/null 2>&1; then
-            echo "Submission successful!"
-            success=true
-          fi
-
-          if [[ "${success}" != "true" ]]; then
-            echo "Submission failed after all attempts." >&2
-            exit 1
+            echo "Signed XPI available!"
+            echo "has_xpi=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No XPI yet (listed channel - pending review)"
+            echo "has_xpi=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload signed XPI artifact
+        if: steps.submit.outputs.has_xpi == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: firefox-addon-${{ steps.manifest.outputs.version }}
           path: ${{ env.ARTIFACTS_DIR }}/*.xpi
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Publish XPI to firefox branch
+        if: steps.submit.outputs.has_xpi == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.41.2",
+  "version": "3.41.3",
   "homepage_url": "http://socialstream.ninja/",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
# Description

## Summary
This PR fixes a failure in the Firefox deployment workflow that occurs when submitting "listed" versions to the Mozilla Add-ons (AMO) repository. It ensures the CI/CD pipeline correctly handles scenarios where a signed XPI file is not immediately generated (common for listed submissions awaiting manual review).

## Context
When using the Firefox extension signing tool with the `--approval-timeout 0` flag for **listed** channels:
- The submission is successfully received by Mozilla for review.
- However, an `.xpi` file is **not** produced immediately.
- For **unlisted** channels, the XPI is signed and returned instantly.

Previously, the workflow would fail during the upload or branch-publish steps because it expected the XPI artifact to exist regardless of the submission type.

## Key Changes
- **Workflow Logic Update:** Added conditional checks to the GitHub Actions workflow to verify the existence of the `.xpi` file before attempting to upload it to releases or publish it to the distribution branch.
- **Improved Robustness:** Prevents the "Firefox workflow" from reporting a failure when the submission to AMO was actually successful but is simply pending review.
- **Version Bump:** Incremented version to `3.41.3`.

## How to Test
1. **CI/CD Observation:** Trigger the Firefox deployment workflow.
2. **Verify Listed Channel:** Ensure that if a listed submission is made, the subsequent "Upload" steps are skipped gracefully instead of failing the build.
3. **Verify Unlisted Channel:** Ensure that for unlisted/self-hosted builds, the XPI is still correctly identified and uploaded as before.

## Affected Components
- `.github/workflows/` (Firefox deployment scripts)
- `package.json` (Version update)