### PR TITLE
feat: switch Firefox to unlisted channel for immediate XPI

### DIFF
--- a/.github/workflows/firefox-addon-store.yml
+++ b/.github/workflows/firefox-addon-store.yml
@@ -9,8 +9,8 @@ on:
       channel:
         description: AMO channel (unlisted = immediate signing, listed = store review)
         type: choice
-        options: [listed, unlisted]
-        default: listed
+        options: [unlisted, listed]
+        default: unlisted
 
 permissions:
   contents: write
@@ -57,7 +57,7 @@ jobs:
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
-          WEB_EXT_CHANNEL: ${{ github.event.inputs.channel || 'listed' }}
+          WEB_EXT_CHANNEL: ${{ github.event.inputs.channel || 'unlisted' }}
         run: |
           set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -300,15 +300,13 @@ While Google will eventually kill manifest version 2 extensions, it's possible t
 
 ### Browser Extension Stores
 
-You can install Social Stream Ninja from the official browser extension stores:
-
 **Chrome Web Store** (Chrome, Edge, Brave):
 https://chromewebstore.google.com/detail/social-stream-ninja/cppibjhfemifednoimlblfcmjgfhfjeg
 
-**Firefox Add-ons**:
-https://addons.mozilla.org/en-US/firefox/addon/71c9e650a4eb454aae9b/
+**Firefox** (direct XPI download):
+https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi
 
-Note: Store versions are updated every few weeks due to the review process. For the latest features, you can [manually install from GitHub](#manually-install-extension) or download from [GitHub Releases](https://github.com/steveseguin/social_stream/releases).
+Note: The Chrome Web Store version is updated every few weeks due to the review process. For the latest features, you can [manually install from GitHub](#manually-install-extension).
 
 The Chrome version is based on Manifest v3, and will require you to leave a small browser tab open to use it.
 
@@ -328,27 +326,15 @@ And for a video that covers two ways to update the extension: https://youtu.be/Z
 
 #### Firefox support
 
-Social Stream Ninja is available for Firefox via the Firefox Add-ons store:
+Download the signed Firefox extension (XPI):
+https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi
 
-https://addons.mozilla.org/en-US/firefox/addon/71c9e650a4eb454aae9b/
-
-You can also download the signed XPI directly from [GitHub Releases](https://github.com/steveseguin/social_stream/releases) for manual installation.
+To install: Open Firefox, go to `about:addons`, click the gear icon, select "Install Add-on From File...", and choose the downloaded XPI.
 
 **Note:** The Firefox version has some limitations compared to Chrome:
 - TTS voice models are not included (uses system voices only)
 - Tab capture and debugger features are not available
-
-<details>
-<summary>Manual installation (for development/testing)</summary>
-
-If you prefer to load the extension manually for development:
-
- - Download+extract or clone the SocialStream code somewhere.
- - Go to `about:debugging#/runtime/this-firefox` in Firefox and select Load Temporary Add-on.
- - Select any file inside the SocialStream folder.
- - This is a temporary install and settings will not persist.
-
-</details>
+- Auto-responder feature is not supported
 
 ### Standalone version of the app
 

--- a/docs/download.html
+++ b/docs/download.html
@@ -137,11 +137,10 @@
                             <img src="../icons/firefox.svg" alt="Firefox">
                         </div>
                         <h3>Firefox</h3>
-                        <p>Official Firefox extension from Mozilla Add-ons store.</p>
+                        <p>Signed Firefox extension for direct installation.</p>
                         <p class="note">Some features like TTS models and tab capture are not available in Firefox.</p>
-                        <a href="#firefox-install" class="view-installation-instructions btn btn-text">View Installation Options</a>
-                        <a href="https://addons.mozilla.org/en-US/firefox/addon/71c9e650a4eb454aae9b/" class="btn btn-primary">Firefox Add-ons Store</a>
-                        <a href="https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi" class="btn btn-secondary">Download XPI</a>
+                        <a href="#firefox-install" class="view-installation-instructions btn btn-text">View Installation Instructions</a>
+                        <a href="https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi" class="btn btn-primary">Download XPI</a>
                     </div>
                 </div>
             </div>
@@ -276,18 +275,22 @@
                 <div class="step">
                     <div class="step-number">1</div>
                     <div class="step-content">
-                        <h3>Install from Firefox Add-ons Store (Recommended)</h3>
-                        <p>The easiest way to install Social Stream Ninja for Firefox is from the official Mozilla Add-ons store.</p>
-                        <a href="https://addons.mozilla.org/en-US/firefox/addon/71c9e650a4eb454aae9b/" class="btn btn-primary">Install from Firefox Add-ons</a>
+                        <h3>Download the XPI File</h3>
+                        <p>Download the signed Firefox extension file.</p>
+                        <a href="https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi" class="btn btn-primary">Download XPI</a>
                     </div>
                 </div>
                 <div class="step">
                     <div class="step-number">2</div>
                     <div class="step-content">
-                        <h3>Or Download Signed XPI</h3>
-                        <p>You can also download the signed XPI file directly and install it manually in Firefox.</p>
-                        <a href="https://raw.githubusercontent.com/steveseguin/social_stream/firefox/social-stream-ninja.xpi" class="btn btn-secondary">Download XPI</a>
-                        <p class="note">To install: Open Firefox, go to <code>about:addons</code>, click the gear icon, select "Install Add-on From File", and choose the downloaded XPI.</p>
+                        <h3>Install in Firefox</h3>
+                        <p>Open Firefox and install the extension:</p>
+                        <ul>
+                            <li>Go to <code>about:addons</code> in Firefox</li>
+                            <li>Click the gear icon (settings)</li>
+                            <li>Select "Install Add-on From File..."</li>
+                            <li>Choose the downloaded XPI file</li>
+                        </ul>
                     </div>
                 </div>
                 <div class="step">
@@ -303,19 +306,6 @@
                     </div>
                 </div>
             </div>
-            <details class="manual-install-details">
-                <summary>Manual Installation (for development/testing)</summary>
-                <div class="installation-steps">
-                    <div class="step">
-                        <div class="step-content">
-                            <p>1. Download and extract the <a href="https://github.com/steveseguin/social_stream/archive/refs/heads/main.zip">ZIP file</a></p>
-                            <p>2. Go to <code>about:debugging#/runtime/this-firefox</code> in Firefox</p>
-                            <p>3. Click "Load Temporary Add-on" and select any file in the extracted folder</p>
-                            <p class="note">This is a temporary install. Settings will not persist after closing Firefox.</p>
-                        </div>
-                    </div>
-                </div>
-            </details>
         </div>
     </section>
 	

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.41.3",
+  "version": "3.41.4",
   "homepage_url": "http://socialstream.ninja/",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary
- Switch Firefox workflow to unlisted channel (immediate signing, no Mozilla review)
- Update docs/download.html with simplified Firefox XPI download and install instructions
- Update README.md Firefox section with direct XPI link
- Remove all Firefox Add-ons store references
- Bump version to 3.41.4

## Changes
- Workflow now defaults to `unlisted` channel
- XPI will be immediately signed and uploaded to `firefox` branch
- Users download XPI directly and install via `about:addons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)