### PR TITLE
fix: wait for signed XPI on unlisted channel

### DIFF
--- a/.github/workflows/firefox-addon-store.yml
+++ b/.github/workflows/firefox-addon-store.yml
@@ -75,6 +75,14 @@ jobs:
           max_attempts=4
           backoff=30
 
+          # For unlisted: wait up to 15 min for signed XPI
+          # For listed: don't wait (review takes days)
+          if [[ "$WEB_EXT_CHANNEL" == "unlisted" ]]; then
+            TIMEOUT_ARG=""
+          else
+            TIMEOUT_ARG="--approval-timeout 0"
+          fi
+
           while true; do
             if web-ext sign \
               --api-key "$AMO_JWT_ISSUER" \
@@ -83,7 +91,7 @@ jobs:
               --source-dir "$FIREFOX_BUILD_DIR" \
               --artifacts-dir "$ARTIFACTS_DIR" \
               --amo-metadata "scripts/amo-metadata.json" \
-              --approval-timeout 0; then
+              $TIMEOUT_ARG; then
               echo "Submission to AMO succeeded!"
               break
             fi

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.41.4",
+  "version": "3.41.5",
   "homepage_url": "http://socialstream.ninja/",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary
- Fix: unlisted channel was using `--approval-timeout 0` which skipped downloading the XPI
- Now unlisted channel waits for the signed XPI (usually ~1-2 min)
- Listed channel still uses timeout 0 (review takes days)
- Bump version to 3.41.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)