### PR TITLE
fix: Firefox messaging compatibility and wait for XPI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.41.5",
+  "version": "3.41.6",
   "homepage_url": "http://socialstream.ninja/",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary
- Fix Firefox popup not working due to async message response handling differences
- Fix unlisted channel to wait for signed XPI download
- Bump version to 3.41.6

## Firefox Messaging Fix
Firefox MV3 handles async message responses differently than Chrome:
- **Chrome**: `return true` keeps the message channel open for `sendResponse`
- **Firefox**: Needs to return a Promise instead

Added a shim to `background.js` (via `prepare-firefox.sh`) that wraps the message listener and converts `return true` to a Promise for Firefox compatibility.

## XPI Download Fix
- Removed `--approval-timeout 0` for unlisted channel so it waits for the signed XPI
- Listed channel still uses timeout 0 (review takes days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)