### PR TITLE
fix(app): handle Event Flow Editor link in desktop app context

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Social Stream Ninja",
   "description": "Powerful tooling to engage live chat on Youtube, Twitch, Zoom, and more.",
   "manifest_version": 3,
-  "version": "3.43.1",
+  "version": "3.43.2",
   "homepage_url": "http://socialstream.ninja/",
   "browser_specific_settings": {
     "gecko": {

--- a/popup.js
+++ b/popup.js
@@ -170,7 +170,19 @@ if (document.readyState === "complete" || document.readyState === "interactive")
 
 // Function to open Event Flow Editor
 function openEventFlowEditor() {
-    // For all contexts, just open actions/index.html
+    if (ssapp) {
+        // In ssapp context, the remote actions/index.html is disconnected from the local context
+        // Try to tell ssapp to switch to the editor view via postMessage
+        try {
+            window.parent.postMessage({ action: 'switchToEventFlowEditor' }, '*');
+        } catch (e) {
+            console.warn('Could not send postMessage to parent:', e);
+        }
+        // Also show message for older ssapp versions that don't have the listener yet
+        alert('In the desktop app, use the 🪤 Event Flow Editor option in the navigation menu.');
+        return;
+    }
+    // For extension context, open actions/index.html
     window.open('actions/index.html', '_blank');
 }
 // Make function available globally


### PR DESCRIPTION
- Add conditional logic in openEventFlowEditor to detect ssapp context
- Use postMessage to request editor switch instead of opening broken remote link
- Display alert for older ssapp versions without postMessage listener
- Bump version to 3.43.2

[auto-enhanced]