### PR TITLE
feat(manifest): add support for non-www Whatnot URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -260,6 +260,7 @@
     "https://app.livestorm.co/*/live?*",
     "https://steamcommunity.com/broadcast/chatonly/*",
     "https://www.whatnot.com/live/*",
+    "https://whatnot.com/live/*",
     "https://jaco.live/*",
     "https://www.younow.com/*",
     "https://chat.truffle.vip/chat/",
@@ -709,7 +710,8 @@
         "./sources/whatnot.js"
       ],
       "matches": [
-        "https://www.whatnot.com/live/*"
+        "https://www.whatnot.com/live/*",
+        "https://whatnot.com/live/*"
       ]
     },
     {


### PR DESCRIPTION
Updates host_permissions and content script matches in manifest.json to include the base domain pattern `https://whatnot.com/live/*`.

This ensures the extension loads correctly when users access Whatnot live streams without the 'www' prefix.

[auto-enhanced]