### PR TITLE
fix(youtube): restore passive recovery for popout chat

### DIFF
--- a/sources/youtube.js
+++ b/sources/youtube.js
@@ -710,6 +710,7 @@
 							data.sourceImg = channelThumbnail;
 						}
 
+						markYouTubeChatActivity();
 						chrome.runtime.sendMessage(
 							chrome.runtime.id,
 							{ message: data },
@@ -1255,6 +1256,7 @@
 		//}
 
 		try {
+			markYouTubeChatActivity();
 			chrome.runtime.sendMessage(
 				chrome.runtime.id,
 				{
@@ -1316,14 +1318,16 @@
 				return;
 			}
 			if (typeof request === "object") {
-				
+
 				if ("state" in request) {
 					isExtensionOn = request.state;
+					refreshYouTubeRecoveryInterval();
 				}
-				
+
 				if ("settings" in request) {
 					settings = request.settings;
 					sendResponse(true);
+					refreshYouTubeRecoveryInterval();
 					if (settings.bttv) {
 						chrome.runtime.sendMessage(chrome.runtime.id, { getBTTV: true }, function (response) {});
 					}
@@ -1414,12 +1418,14 @@
 		
 		if ("state" in response){
 			isExtensionOn = response.state;
+			refreshYouTubeRecoveryInterval();
 		}
-		
+
 		if (typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.lastError) { return; }
 		response = response || {};
 		if ("settings" in response) {
 			settings = response.settings;
+			refreshYouTubeRecoveryInterval();
 
 			if (settings.bttv && !BTTV) {
 				chrome.runtime.sendMessage(chrome.runtime.id, { getBTTV: true }, function (response) {
@@ -1524,6 +1530,146 @@
 	var youtubeEmptySince = 0;
 	var youtubeLastObserverRefreshAt = 0;
 	var youtubeObserverRefreshCooldownMs = 4000;
+
+	let youtubeRecoveryInterval = null;
+	const youtubeStaleChatActivityMs = 15 * 60 * 1000;
+	const youtubeMinimumRefreshMs = 10 * 60 * 1000;
+	const youtubeRecoveryCheckMs = 30 * 1000;
+	let lastYouTubeChatActivityAt = 0;
+	let lastYouTubeRefreshTimerResetAt = Date.now();
+	let hasSeenYouTubeChatActivity = false;
+
+	function isDesktopYouTubeRecoveryContext() {
+		return !!(window.ninjafy || window.electronApi);
+	}
+
+	function isYouTubePopoutChatWindow() {
+		const href = window.location.href || "";
+		if (!href.includes("youtube.com/live_chat") && !href.includes("studio.youtube.com/live_chat")) {
+			return false;
+		}
+		return href.includes("is_popout=1");
+	}
+
+	function isPassiveYouTubeRecoveryEnabled() {
+		if (!isDesktopYouTubeRecoveryContext()) {
+			return false;
+		}
+		if (!isExtensionOn) {
+			return false;
+		}
+		if (!isYouTubePopoutChatWindow()) {
+			return false;
+		}
+		if (settings && settings.disabletiktokpoke) {
+			return false;
+		}
+		return true;
+	}
+
+	function markYouTubeChatActivity() {
+		hasSeenYouTubeChatActivity = true;
+		lastYouTubeChatActivityAt = Date.now();
+	}
+
+	function markYouTubeUserActivity() {
+		lastYouTubeRefreshTimerResetAt = Date.now();
+	}
+
+	function getYouTubeChatInputElement() {
+		return document.querySelector('yt-live-chat-text-input-field-renderer div#input[contenteditable], div#input[contenteditable]');
+	}
+
+	function isYouTubeChatInputFocused() {
+		const activeElement = document.activeElement;
+		if (!activeElement) {
+			return false;
+		}
+		if (activeElement === getYouTubeChatInputElement()) {
+			return true;
+		}
+		if (activeElement.closest && activeElement.closest("yt-live-chat-text-input-field-renderer")) {
+			return true;
+		}
+		return false;
+	}
+
+	function isTrustedYouTubeInteraction(event) {
+		return !!(event && event.isTrusted);
+	}
+
+	function maybeRecoverYouTubeChat() {
+		if (!isPassiveYouTubeRecoveryEnabled()) {
+			return;
+		}
+		if (!hasSeenYouTubeChatActivity || !lastYouTubeChatActivityAt) {
+			return;
+		}
+		const now = Date.now();
+		if ((now - lastYouTubeChatActivityAt) < youtubeStaleChatActivityMs) {
+			return;
+		}
+		if ((now - lastYouTubeRefreshTimerResetAt) < youtubeMinimumRefreshMs) {
+			return;
+		}
+		if (isYouTubeChatInputFocused()) {
+			markYouTubeUserActivity();
+			return;
+		}
+		lastYouTubeRefreshTimerResetAt = now;
+		try {
+			window.location.reload();
+		} catch (e) {}
+	}
+
+	function refreshYouTubeRecoveryInterval() {
+		if (youtubeRecoveryInterval) {
+			clearInterval(youtubeRecoveryInterval);
+			youtubeRecoveryInterval = null;
+		}
+		if (!isPassiveYouTubeRecoveryEnabled()) {
+			return;
+		}
+		youtubeRecoveryInterval = setInterval(function () {
+			maybeRecoverYouTubeChat();
+		}, youtubeRecoveryCheckMs);
+	}
+
+	document.addEventListener("focusin", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
+
+	document.addEventListener("mousedown", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
+
+	document.addEventListener("touchstart", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
+
+	document.addEventListener("keydown", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
+
+	document.addEventListener("input", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
+
+	document.addEventListener("wheel", function (event) {
+		if (isTrustedYouTubeInteraction(event)) {
+			markYouTubeUserActivity();
+		}
+	}, true);
 
 	function applyLargerFont() {
 		if (!largerFontApplied) {
@@ -1783,6 +1929,7 @@
 			data.chatname = getAllContentNodes(ele.querySelector(".text-owner-light, .text-owner-dark"));
 			data.chatmessage = getAllContentNodes(ele.querySelector("span.cursor-auto.align-middle"));
 			data.type = "youtube";
+			markYouTubeChatActivity();
 			chrome.runtime.sendMessage(
 				chrome.runtime.id,
 				{


### PR DESCRIPTION
## Problem

Popout YT chat goes silent mid-stream: container stays mounted with old messages but no new items are injected (#642, #645). The current MutationObserver recovery only fires on disconnect / empty container, so the "DOM intact, no new items" case slips through.

## Fix

Restores the activity-based recovery from c4dc25f2 (dropped in e9bac547 with no documented reason) alongside the existing observer.

- Tracks chat activity on each processed message and user activity (focusin / mousedown / touchstart / keydown / input / wheel, trusted only).
- Every 30s: if 15+ min without chat AND 10+ min without user interaction, `window.location.reload()`.
- Skipped while the chat input is focused.
- Popout-only (`is_popout=1`, electron / ninjafy).
- Killswitched by `disabletiktokpoke`.
- Guarded by `hasSeenYouTubeChatActivity` so no reload before the first message.

## Test plan

- [x] `node --check sources/youtube.js` passes.
- [ ] Real soak in a desktop popout: leave it idle ~16 min with no chat or interaction, confirm exactly one reload.

Refs #642 #645