### PR TITLE
fix(vpzone): correct WebSocket URL + support chat-dock/popout pages

### DIFF
--- a/sources/vpzone.js
+++ b/sources/vpzone.js
@@ -48,8 +48,18 @@
 
 	function getChannelSlugFromUrl() {
 		try {
-			var match = window.location.pathname.match(/^\/watch\/([^\/?#]+)/);
-			return match ? decodeURIComponent(match[1]) : "";
+			// Match /watch/{slug}, /overlay/chat/{token}?channel={slug},
+			// /overlay/chat-dock/{token}?channel={slug}, /u/{username}
+			var path = window.location.pathname;
+			var match =
+				path.match(/^\/watch\/([^\/?#]+)/) ||
+				path.match(/^\/u\/([^\/?#]+)/);
+			if (match) return decodeURIComponent(match[1]);
+			// Chat dock / overlay pages pass channel as query param
+			var params = new URLSearchParams(window.location.search);
+			var channel = params.get("channel");
+			if (channel) return decodeURIComponent(channel);
+			return "";
 		} catch (e) {
 			return "";
 		}

--- a/sources/websocket/vpzone.html
+++ b/sources/websocket/vpzone.html
@@ -291,7 +291,7 @@
         <section class="card">
             <h1>VPZone WebSocket Source</h1>
             <p>Read-only VPZone websocket bridge. It subscribes to a stream username and forwards <code>chat_message</code>, follow/subscription events, and optional presence viewer counts.</p>
-            <p class="hint">URL params supported: <code>?channel=lordwaffl3</code>, <code>?ws=wss://vpzone.tv/ws</code>, and <code>?token=YOUR_BEARER_TOKEN</code>.</p>
+            <p class="hint">URL params supported: <code>?channel=lordwaffl3</code>, <code>?ws=wss://chat.nexus-7.vpzone.tv/ws</code>, and <code>?token=YOUR_BEARER_TOKEN</code>.</p>
         </section>
 
         <section class="card">
@@ -303,7 +303,7 @@
                 </div>
                 <div>
                     <label for="ws-url">WebSocket URL</label>
-                    <input id="ws-url" type="text" autocomplete="off" value="wss://vpzone.tv/ws" />
+                    <input id="ws-url" type="text" autocomplete="off" value="wss://chat.nexus-7.vpzone.tv/ws" />
                 </div>
                 <div>
                     <label for="auth-token">Bearer Token</label>

--- a/sources/websocket/vpzone.js
+++ b/sources/websocket/vpzone.js
@@ -3,7 +3,7 @@
 	const SOURCE_NAME = "VPZone";
 	const SOURCE_IMG = HOST + "/favicon.ico";
 	const CONFIG_KEY = "vpzoneWsConfig";
-	const DEFAULT_CONFIG = { channel: "", wsUrl: "wss://vpzone.tv/ws", token: "" };
+	const DEFAULT_CONFIG = { channel: "", wsUrl: "wss://chat.nexus-7.vpzone.tv/ws", token: "" };
 	const RECONNECT_DELAY_MS = 4000;
 	const MAX_SEEN_IDS = 1500;
 	const READY_STATE = { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 };


### PR DESCRIPTION
## Summary
- Fixed VPZone WebSocket URL from `wss://vpzone.tv/ws` (returns 404) to `wss://chat.nexus-7.vpzone.tv/ws` (the actual chat server)
- Added content script support for chat-dock, chat popout, and profile pages

## Changes
- `sources/websocket/vpzone.js`: Updated `DEFAULT_CONFIG.wsUrl`
- `sources/websocket/vpzone.html`: Updated default input value + docs
- `sources/vpzone.js`: `getChannelSlugFromUrl()` now matches:
  - `/watch/{slug}` (existing)
  - `/u/{username}` (profile page — new)
  - `/overlay/chat/{token}?channel={slug}` (chat popout — new)
  - `/overlay/chat-dock/{token}?channel={slug}` (OBS dock — new)

## Test plan
- [ ] WebSocket connects to `wss://chat.nexus-7.vpzone.tv/ws?channel=artanime`
- [ ] Extension captures chat on `/watch/artanime`
- [ ] Extension captures chat on chat-dock page
- [ ] Extension captures chat on chat popout overlay page