### PR TITLE
[codex] Use YouTube handle lookup for live chat context

### DIFF
--- a/providers/youtube/contextResolver.js
+++ b/providers/youtube/contextResolver.js
@@ -194,6 +194,17 @@ export function createYouTubeLiveChatContextResolver(options = {}) {
       return null;
     };
 
+    const attemptByHandle = async (handle) => {
+      const url = new URL(`${API_ROOT}/channels`);
+      url.searchParams.set('part', 'snippet,statistics');
+      url.searchParams.set('forHandle', handle);
+      const data = await fetchJson(url.toString(), { fetchImpl, token: tokenRef, signal });
+      if (Array.isArray(data.items) && data.items.length > 0) {
+        return data.items[0];
+      }
+      return null;
+    };
+
     const attemptBySearch = async (query) => {
       const searchUrl = new URL(`${API_ROOT}/search`);
       searchUrl.searchParams.set('part', 'snippet');
@@ -219,11 +230,15 @@ export function createYouTubeLiveChatContextResolver(options = {}) {
     }
 
     if (!channelItem && trimmed.startsWith('@')) {
-      channelItem = await attemptBySearch(trimmed);
+      channelItem = await attemptByHandle(trimmed);
     }
 
     if (!channelItem && !trimmed.startsWith('UC') && !trimmed.startsWith('@')) {
       channelItem = await attemptByUsername(trimmed);
+    }
+
+    if (!channelItem && !trimmed.startsWith('UC')) {
+      channelItem = await attemptByHandle(trimmed);
     }
 
     if (!channelItem) {


### PR DESCRIPTION
## Summary
- Add YouTube Data API `forHandle` lookup for channel context resolution.
- Prefer direct handle lookup for `@handle` inputs before falling back to search.
- Keep legacy username lookup for bare non-channel-ID inputs, then try handle lookup and search.

## Validation
- `node --check providers\youtube\contextResolver.js`
- Included in live YouTube lookup validation from the desktop app investigation.