### PR TITLE
docs: fix receive typo in API docs

### DIFF
--- a/api.md
+++ b/api.md
@@ -269,7 +269,7 @@ The channel system allows for more granular control over message routing:
 
 When specifying channels, you're defining which channels to receive messages from (IN_CHANNEL) and which to send messages to (OUT_CHANNEL). This allows different components of your setup to communicate on separate channels, reducing noise and improving organization.
 
-When a message is sent, it goes to the specified output channel. Those who have that channel set as their input channel will recieve the message.
+When a message is sent, it goes to the specified output channel. Those who have that channel set as their input channel will receive the message.
 
 ### Available Commands
 


### PR DESCRIPTION
## Problem
The API channel documentation has a visible typo: "recieve".

## Solution
Corrected it to "receive".

## Validation
- `git diff --check`
- `git grep -n -i 'recieve' -- api.md || true`\n\nConfidence: 85/100 (docs/typo).\n